### PR TITLE
84 wpla 2x bug precipitation always zero with knmi uurgegevens

### DIFF
--- a/weather_provider_api/routers/weather/api_models.py
+++ b/weather_provider_api/routers/weather/api_models.py
@@ -153,7 +153,7 @@ class FloatEncoder(json.JSONEncoder):
             elif obj == -FloatEncoder.INFINITY:
                 yield "-Infinity"
             else:
-                yield format(obj, ".2f")
+                yield format(obj, ".4f")
         elif isinstance(obj, dict):
             last_index = len(obj) - 1
             yield "{"

--- a/weather_provider_api/routers/weather/sources/knmi/client/knmi_downloader.py
+++ b/weather_provider_api/routers/weather/sources/knmi/client/knmi_downloader.py
@@ -59,12 +59,11 @@ class KNMIDownloader:
         files_for_dataset = files_for_dataset.json()  # Reformat to JSON
         file_list = files_for_dataset.get("files")
 
-        if not self.download_folder.exists():
-            self.download_folder.mkdir()
-        else:
-            for root, dirs, files in os.walk(self.download_folder):
-                for file in files:
-                    os.remove(os.path.join(root, file))
+        if self.download_folder.exists():
+            self.download_folder.rmdir()  # Remove the folder (immediately cleaning it) if it already existed
+
+        # Create a nice clean folder to use
+        self.download_folder.mkdir()
 
         for file in file_list:
             self.knmi_download_file_to_temp(

--- a/weather_provider_api/routers/weather/utils/serializers.py
+++ b/weather_provider_api/routers/weather/utils/serializers.py
@@ -105,7 +105,7 @@ def to_csv(unserialized_data: xarray.Dataset, coords):
             cols.remove("lon")
             cols = ["lat", "lon"] + cols
 
-        csv_str = df.to_csv(columns=cols, header=False, float_format="%.2f")
+        csv_str = df.to_csv(columns=cols, header=False, float_format="%.4f")
         csv_strings[serialize_coords(c)] = csv_str
 
     cols = ["time"] + cols
@@ -126,10 +126,10 @@ def get_weather_slice_for_coords(coord, unserialized_data) -> pd.DataFrame:
     # We then switch to a Pandas dataframe
     weather = unserialized_data.sel(lat=coord[0], lon=coord[1])
     if weather.dims["time"] == 1:
-        # Because the singular dimension of time can't be squeezed..
+        # Because a single moment in time can't be squeezed...
         df = weather.to_dataframe()
     else:
-        # .. and multiple times need to be..
+        # ... and multiple times need to be.
         df = weather.squeeze().to_dataframe()
     return df
 


### PR DESCRIPTION
### Fix for issue #84

The number of stored decimals for float values has been doubled from 2 to 4. This fixes a bug where the field "Uurgegevens" would always end up as 0 for text based files, due to the default harmonization level being in **m/h** rather than **mm/h**. Due to API consistency this choice of unit will remain the same for version 2.x of the API calls. 

**_It is not done to change the output of an API without proper warning in advance,  which is why we change the unit depth, rather than the unit itself..._**

